### PR TITLE
Fix safe.directory error message when use GITHUB_WORKSPACE

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,5 +31,7 @@ else
     export CONFIG_FILE="${GITHUB_WORKSPACE}/mkdocs.yml"
 fi
 
+# workaroun, see https://github.com/actions/checkout/issues/766
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
 cd ${GITHUB_WORKSPACE}
 mkdocs build --config-file ${CONFIG_FILE}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,8 @@ else
     export CONFIG_FILE="${GITHUB_WORKSPACE}/mkdocs.yml"
 fi
 
-# workaroun, see https://github.com/actions/checkout/issues/766
+# workaround, see https://github.com/actions/checkout/issues/766
 git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
 cd ${GITHUB_WORKSPACE}
 mkdocs build --config-file ${CONFIG_FILE}


### PR DESCRIPTION
When you upgrade your git to a specific version, users will start to see the error:
Error: fatal: unsafe repository ...

This error occurred when I was using the runner folder to check out my project, and this action was using GITHUB_WORKSPACE folder to build. So, we need add GITHUB_WORKFSPACE to safe.directory

The problem is opened here: https://github.com/actions/checkout/issues/766
